### PR TITLE
Mention ttf-mscorefonts-installer as a package for headless Linux usage.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -193,7 +193,7 @@ Most headless (e.g. no X11) environments will need some additional packages to b
 # Install dependencies
 apt-get update &&\
     apt-get install -y libgtk2.0-0 libgconf-2-4 \
-    libasound2 libxtst6 libxss1 libnss3 xvfb
+    libasound2 libxtst6 libxss1 libnss3 xvfb ttf-mscorefonts-installer
 
 # Start Xvfb
 Xvfb -ac -screen scrn 1280x2000x24 :9.0 &


### PR DESCRIPTION
I wanted to make note of the `ttf-mscorefonts-installer` package as a recommend install for headless X11 instances because I found that most websites rendered with absolutely no text since they were using Helvetica, Times, etc. fonts.  Those faces apparently weren't present in whatever X11 fonts are installed by default, but they are installed by this package.