### PR TITLE
Exit with the same code as Electron.

### DIFF
--- a/bin/electroshot.js
+++ b/bin/electroshot.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 var fs = require('fs'),
     path = require('path'),
+    process = require('process'),
     spawn = require('child_process').spawn,
     os = require('os');
 
@@ -107,6 +108,7 @@ function runElectron() {
     }
     if (code !== 0) {
       console.log('Electron exited with code ' + code);
+      process.exit(code);
     } else {
       console.log(logSymbols.success, 'Generated ' + tasks.length + ' screenshot' + (tasks.length > 1 ? 's' : '') + '.');
     }


### PR DESCRIPTION
If Electron fails (e.g., exits with code 1), electroshot will still exit with code 0.  This makes it more difficult to determine if electroshot failed (I have to grep for "Electron exited with...").  This is a simple fix to have electroshot exit with the same code that Electron does.