### PR TITLE
Round getBoundingClientRect() dimensions

### DIFF
--- a/electron/preload.js
+++ b/electron/preload.js
@@ -51,10 +51,10 @@ ipc.on('get-dimensions', function ensureRendered(event, selector) {
     return;
   }
   ipc.send('return-dimensions', {
-    x: result.top,
-    y: result.left,
-    width: result.right - result.left,
-    height: result.bottom - result.top,
+    x: Math.floor(result.left),
+    y: Math.floor(result.top),
+    width: Math.ceil(result.right - result.left),
+    height: Math.ceil(result.bottom - result.top),
   });
 });
 


### PR DESCRIPTION
Capturing elements with non-integer bounding rectangles throws a difficult-to-decipher error in electron, which I eventually traced back to [the docs](https://github.com/electron/electron/blob/master/docs/api/structures/rectangle.md):

> ### Rectangle Object
> 
> * `x` Number - The x coordinate of the origin of the rectangle (must be an integer)
> * `y` Number - The y coordinate of the origin of the rectangle (must be an integer)
> * `width` Number - The width of the rectangle (must be an integer)
> * `height` Number - The height of the rectangle (must be an integer)

Rounding the returned bounds (with `Math.floor()` on the upper left coordinates and `Math.ceil()` on the lower right, to prevent clipping) fixes this.